### PR TITLE
fix the version of the EKS/AWS module

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -52,6 +52,7 @@ module "vpc" {
 
 module "eks" {
   source = "terraform-aws-modules/eks/aws"
+  version = "17.24.0"
 
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version


### PR DESCRIPTION
The latest version (18.*) of the AWS EKS terraform module is not 
compatible with the current code. Fixing the version to the latest 17.*
version fixes this issue without making a lot of changes.

Thank you for submitting a pull request to the WrongSecrets app!