### PR TITLE
Add resume script

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2021 Jeroen Willemsen and WrongSecret contributors.
+Copyright (c) 2020-2022 Jeroen Willemsen and WrongSecret contributors.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ Make sure you have the following installed:
 
 Run `./k8s-vault-minkube-start.sh`, when the script is done, then the challenges will wait for you at <http://localhost:8080> . This will allow you to run challenges 1-8, 12-14.
 
+When you stopped the `k8s-vault-minikube-start.sh` script and want to resume the port forward run: `k8s-vault-minikube-resume.sh`. This is because if you run the start script again it will replace the secret in the vault and not update the secret-challenge application with the new secret.
+
 ## Cloud Challenges
 
 _Can be used for challenges 1-14_

--- a/aws/README.md
+++ b/aws/README.md
@@ -44,7 +44,7 @@ Are you done playing? Please run `terraform destroy` twice to clean up.
 Run `AWS_PROFILE=<your_profile> k8s-vault-aws-start.sh` and connect to [http://localhost:8080](http://localhost:8080) when it's ready to accept connections (you'll read the line `Forwarding from 127.0.0.1:8080 -> 8080` in your console). Now challenge 9 and 10 should be available as well.
 
 ### Resume it
-When you stopped the `k8s-vault-aws-start.sh` script and which to resume the port forward run: `k8s-vault-aws-resume.sh`. This is because if you run the start script again it will replace the secret in the vault and not update the secret-challenge application with the new secret.
+When you stopped the `k8s-vault-aws-start.sh` script and want to resume the port forward run: `k8s-vault-aws-resume.sh`. This is because if you run the start script again it will replace the secret in the vault and not update the secret-challenge application with the new secret.
 
 ### Clean it up
 

--- a/aws/README.md
+++ b/aws/README.md
@@ -43,6 +43,9 @@ Are you done playing? Please run `terraform destroy` twice to clean up.
 
 Run `AWS_PROFILE=<your_profile> k8s-vault-aws-start.sh` and connect to [http://localhost:8080](http://localhost:8080) when it's ready to accept connections (you'll read the line `Forwarding from 127.0.0.1:8080 -> 8080` in your console). Now challenge 9 and 10 should be available as well.
 
+### Resume it
+When you stopped the `k8s-vault-aws-start.sh` script and which to resume the port forward run: `k8s-vault-aws-resume.sh`. This is because if you run the start script again it will replace the secret in the vault and not update the secret-challenge application with the new secret.
+
 ### Clean it up
 
 When you're done:

--- a/aws/k8s-vault-aws-resume.sh
+++ b/aws/k8s-vault-aws-resume.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+kubectl port-forward vault-0 8200:8200 &
+kubectl port-forward \
+  $(kubectl get pod -l app=secret-challenge -o jsonpath="{.items[0].metadata.name}") \
+  8080:8080 \
+  ;

--- a/azure/README.md
+++ b/azure/README.md
@@ -42,7 +42,7 @@ Are you done playing? Please run `terraform destroy` twice to clean up.
 Run `./k8s-vault-azure-start.sh` and connect to [http://localhost:8080](http://localhost:8080) when it's ready to accept connections (you'll read the line `Forwarding from 127.0.0.1:8080 -> 8080` in your console). Now challenge 9 and 10 should be available as well.
 
 ### Resume it
-When you stopped the `k8s-vault-azure-start.sh` script and which to resume the port forward run: `k8s-vault-azure-resume.sh`. This is because if you run the start script again it will replace the secret in the vault and not update the secret-challenge application with the new secret.
+When you stopped the `k8s-vault-azure-start.sh` script and want to resume the port forward run: `k8s-vault-azure-resume.sh`. This is because if you run the start script again it will replace the secret in the vault and not update the secret-challenge application with the new secret.
 
 ### Clean it up
 

--- a/azure/README.md
+++ b/azure/README.md
@@ -41,6 +41,9 @@ Are you done playing? Please run `terraform destroy` twice to clean up.
 
 Run `./k8s-vault-azure-start.sh` and connect to [http://localhost:8080](http://localhost:8080) when it's ready to accept connections (you'll read the line `Forwarding from 127.0.0.1:8080 -> 8080` in your console). Now challenge 9 and 10 should be available as well.
 
+### Resume it
+When you stopped the `k8s-vault-azure-start.sh` script and which to resume the port forward run: `k8s-vault-azure-resume.sh`. This is because if you run the start script again it will replace the secret in the vault and not update the secret-challenge application with the new secret.
+
 ### Clean it up
 
 When you're done:

--- a/azure/k8s-vault-azure-resume.sh
+++ b/azure/k8s-vault-azure-resume.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+kubectl port-forward vault-0 8200:8200 &
+kubectl port-forward \
+  $(kubectl get pod -l app=secret-challenge -o jsonpath="{.items[0].metadata.name}") \
+  8080:8080 \
+  ;

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -46,6 +46,9 @@ Are you done playing? Please run `terraform destroy` twice to clean up.
 
 Run `./k8s-vault-gcp-start.sh` and connect to [http://localhost:8080](http://localhost:8080) when it's ready to accept connections (you'll read the line `Forwarding from 127.0.0.1:8080 -> 8080` in your console). Now challenge 9 and 10 should be available as well.
 
+### Resume it
+When you stopped the `k8s-vault-gcp-start.sh` script and which to resume the port forward run: `k8s-vault-gcp-resume.sh`. This is because if you run the start script again it will replace the secret in the vault and not update the secret-challenge application with the new secret.
+
 ### Clean it up
 
 When you're done:

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -47,7 +47,7 @@ Are you done playing? Please run `terraform destroy` twice to clean up.
 Run `./k8s-vault-gcp-start.sh` and connect to [http://localhost:8080](http://localhost:8080) when it's ready to accept connections (you'll read the line `Forwarding from 127.0.0.1:8080 -> 8080` in your console). Now challenge 9 and 10 should be available as well.
 
 ### Resume it
-When you stopped the `k8s-vault-gcp-start.sh` script and which to resume the port forward run: `k8s-vault-gcp-resume.sh`. This is because if you run the start script again it will replace the secret in the vault and not update the secret-challenge application with the new secret.
+When you stopped the `k8s-vault-gcp-start.sh` script and want to resume the port forward run: `k8s-vault-gcp-resume.sh`. This is because if you run the start script again it will replace the secret in the vault and not update the secret-challenge application with the new secret.
 
 ### Clean it up
 

--- a/gcp/k8s-vault-gcp-resume.sh
+++ b/gcp/k8s-vault-gcp-resume.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+kubectl port-forward vault-0 8200:8200 &
+kubectl port-forward \
+  $(kubectl get pod -l app=secret-challenge -o jsonpath="{.items[0].metadata.name}") \
+  8080:8080 \
+  ;

--- a/k8s-vault-minkube-resume.sh
+++ b/k8s-vault-minkube-resume.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+kubectl port-forward vault-0 8200:8200 &
+kubectl port-forward \
+  $(kubectl get pod -l app=secret-challenge -o jsonpath="{.items[0].metadata.name}") \
+  8080:8080 \
+  ;


### PR DESCRIPTION
To prevent Vault from breaking after running the start.sh script twice a
resume.sh script has been added only port-forwarding