### PR TITLE
Add CycloneDX SBOM generation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
         <azure.identity.version>1.4.4</azure.identity.version>
         <azure.keyvault.spring.version>2.3.5</azure.keyvault.spring.version>
         <spring.security.version>5.6.2</spring.security.version>
+        <cyclonedx.core.version>7.0.0</cyclonedx.core.version>
     </properties>
 
     <dependencies>
@@ -183,6 +184,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-core-java</artifactId>
+            <version>${cyclonedx.core.version}</version>
+        </dependency>
+
     </dependencies>
 
     <dependencyManagement>
@@ -282,6 +289,32 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>2.5.3</version>
+                <executions>
+                    <execution>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>makeAggregateBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <projectType>library</projectType>
+                    <schemaVersion>1.3</schemaVersion>
+                    <includeBomSerialNumber>true</includeBomSerialNumber>
+                    <includeCompileScope>true</includeCompileScope>
+                    <includeProvidedScope>true</includeProvidedScope>
+                    <includeRuntimeScope>true</includeRuntimeScope>
+                    <includeSystemScope>true</includeSystemScope>
+                    <includeTestScope>false</includeTestScope>
+                    <includeLicenseText>false</includeLicenseText>
+                    <outputFormat>all</outputFormat>
+                    <outputName>bom</outputName>
+                </configuration>
             </plugin>
 <!-- todo: #178 add the missing plugins and profiles from https://central.sonatype.org/publish/publish-maven/-->
         </plugins>


### PR DESCRIPTION
This PR adds SBOM generation on the `install` step, for use with tools like Dependency Track.