### PR TITLE
Changed Answer to Challenge 4 to allow answer with or without single …

### DIFF
--- a/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge4.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge4.java
@@ -31,7 +31,8 @@ public class Challenge4 extends Challenge {
 
     @Override
     public boolean answerCorrect(String answer) {
-        return argBasedPassword.equals(answer);
+        return argBasedPassword.equals(answer) ||
+		argBasedPassword.equals("'${answer}'");
     }
 
     public List<RuntimeEnvironment.Environment> supportedRuntimeEnvironments() {

--- a/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge4.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge4.java
@@ -32,7 +32,7 @@ public class Challenge4 extends Challenge {
     @Override
     public boolean answerCorrect(String answer) {
         return argBasedPassword.equals(answer) 
-        || argBasedPassword.equals("'${answer}'");
+        || argBasedPassword.equals("'" + answer + "'");
     }
 
     public List<RuntimeEnvironment.Environment> supportedRuntimeEnvironments() {

--- a/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge4.java
+++ b/src/main/java/org/owasp/wrongsecrets/challenges/docker/Challenge4.java
@@ -31,8 +31,8 @@ public class Challenge4 extends Challenge {
 
     @Override
     public boolean answerCorrect(String answer) {
-        return argBasedPassword.equals(answer) ||
-		argBasedPassword.equals("'${answer}'");
+        return argBasedPassword.equals(answer) 
+        || argBasedPassword.equals("'${answer}'");
     }
 
     public List<RuntimeEnvironment.Environment> supportedRuntimeEnvironments() {

--- a/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge4Test.java
+++ b/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge4Test.java
@@ -26,7 +26,7 @@ class Challenge4Test {
     void rightAnswerShouldSolveChallenge() {
         var challenge = new Challenge4(scoreCard, "test");
 
-        Assertions.assertThat(challenge.solved("test")).isTrue()
+        Assertions.assertThat(challenge.solved("test")).isTrue();
         Mockito.verify(scoreCard).completeChallenge(challenge);
     } 
     
@@ -34,7 +34,7 @@ class Challenge4Test {
     void rightAnswerWithoutQuotesShouldSolveChallenge() {
         var challenge = new Challenge4(scoreCard, "'test'");
 
-        Assertions.assertThat(challenge.solved("test")).isTrue()
+        Assertions.assertThat(challenge.solved("test")).isTrue();
         Mockito.verify(scoreCard).completeChallenge(challenge);
     }
 

--- a/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge4Test.java
+++ b/src/test/java/org/owasp/wrongsecrets/challenges/docker/Challenge4Test.java
@@ -26,7 +26,15 @@ class Challenge4Test {
     void rightAnswerShouldSolveChallenge() {
         var challenge = new Challenge4(scoreCard, "test");
 
-        Assertions.assertThat(challenge.solved("test")).isTrue();
+        Assertions.assertThat(challenge.solved("test")).isTrue()
+        Mockito.verify(scoreCard).completeChallenge(challenge);
+    } 
+    
+    @Test
+    void rightAnswerWithoutQuotesShouldSolveChallenge() {
+        var challenge = new Challenge4(scoreCard, "'test'");
+
+        Assertions.assertThat(challenge.solved("test")).isTrue()
         Mockito.verify(scoreCard).completeChallenge(challenge);
     }
 


### PR DESCRIPTION
Hi,

This is an attempt to change the answer for challenge 4 to allow with single quotes or without as per the conversation in this issue https://github.com/commjoen/wrongsecrets/issues/288.

Originally I tried to set a new ARG variable but I realised quickly why there are quotes around it as you have to put it in at the time of using the build script and therefore it needs quotes.

I then thought it would surely be easier and no less would be learned if the answer simply accepted `This is just a temporary new version of the password` with or without quotes. 

I am no Java developer, only a tester so feel free to tell me if this is a horrible implementation. I can make tweaks with the right feedback. 

Finally I haven't tested this as I cant seem to get the Maven tests to run locally. It would be great if I could get permission to run the tests in the pipeline.

Thanks