### PR TITLE
Fixed Docker Web Desktop to support docker commands

### DIFF
--- a/Dockerfile.webdesktop
+++ b/Dockerfile.webdesktop
@@ -1,13 +1,19 @@
 FROM lscr.io/linuxserver/webtop:latest
+LABEL NAME="OWASP WrongSecrets Web Desktop" MAINTAINER="Jeroen Willemsen"
 
 RUN \
   echo "**** install packages ****" && \
-  apk add --no-cache keepassxc radare2 aws-cli geany && \
+  apk add --no-cache shadow keepassxc radare2 aws-cli geany && \
+  echo "**** adding abc user to root for Docker ****" && \
+  usermod -aG root abc && \
+  touch /var/run/docker.sock && \
+  chown abc:abc /var/run/docker.sock && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/*
 
-RUN mkdir ~/Desktop
+WORKDIR /config/Desktop
+
 COPY src/main/resources/executables/ /config/Desktop/wrongsecrets
 COPY src/test/resources/alibabacreds.kdbx /var/tmp/helpers
 COPY src/test/resources/alibabacreds.kdbx /config/Desktop/wrongsecrets

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ If you want to play the challenges, but cannot install tools like keepass, Radar
 containers, try the following:
 
 ```shell
-docker run -p 3000:3000 jeroenwillemsen/wrongsecrets-desktop:1.5.2
+docker run -p 3000:3000 -v /var/run/docker.sock:/var/run/docker.sock jeroenwillemsen/wrongsecrets-desktop:1.5.2
 ```
 
 or use something more configurable:


### PR DESCRIPTION
1. Fixed the `Dockerfile.webdesktop` with user permissions so the `docker` commands works fine
2. Also update the `docker run` command with supporting underlying socket

Thank you